### PR TITLE
Update logic for disabling logging

### DIFF
--- a/src/MycilaESPConnect.cpp
+++ b/src/MycilaESPConnect.cpp
@@ -44,7 +44,12 @@
   #include "./espconnect_webpage.h"
 #endif
 
-#ifdef MYCILA_LOGGER_SUPPORT
+#ifndef ESPCONNECT_DEBUG
+  #define LOGD(tag, format, ...)
+  #define LOGI(tag, format, ...)
+  #define LOGW(tag, format, ...)
+  #define LOGE(tag, format, ...)
+#elif defined(MYCILA_LOGGER_SUPPORT)
   #include <MycilaLogger.h>
 extern Mycila::Logger logger;
   #define LOGD(tag, format, ...) logger.debug(tag, format, ##__VA_ARGS__)
@@ -52,33 +57,26 @@ extern Mycila::Logger logger;
   #define LOGW(tag, format, ...) logger.warn(tag, format, ##__VA_ARGS__)
   #define LOGE(tag, format, ...) logger.error(tag, format, ##__VA_ARGS__)
 #elif defined(ESP8266)
-  #ifdef ESPCONNECT_DEBUG
-    #define LOGD(tag, format, ...)                         \
-      {                                                    \
-        Serial.printf("%6lu [%s] DEBUG: ", millis(), tag); \
-        Serial.printf(format "\n", ##__VA_ARGS__);         \
-      }
-    #define LOGI(tag, format, ...)                        \
-      {                                                   \
-        Serial.printf("%6lu [%s] INFO: ", millis(), tag); \
-        Serial.printf(format "\n", ##__VA_ARGS__);        \
-      }
-    #define LOGW(tag, format, ...)                        \
-      {                                                   \
-        Serial.printf("%6lu [%s] WARN: ", millis(), tag); \
-        Serial.printf(format "\n", ##__VA_ARGS__);        \
-      }
-    #define LOGE(tag, format, ...)                         \
-      {                                                    \
-        Serial.printf("%6lu [%s] ERROR: ", millis(), tag); \
-        Serial.printf(format "\n", ##__VA_ARGS__);         \
-      }
-  #else
-    #define LOGD(tag, format, ...)
-    #define LOGI(tag, format, ...)
-    #define LOGW(tag, format, ...)
-    #define LOGE(tag, format, ...)
-  #endif
+  #define LOGD(tag, format, ...)                         \
+    {                                                    \
+      Serial.printf("%6lu [%s] DEBUG: ", millis(), tag); \
+      Serial.printf(format "\n", ##__VA_ARGS__);         \
+    }
+  #define LOGI(tag, format, ...)                        \
+    {                                                   \
+      Serial.printf("%6lu [%s] INFO: ", millis(), tag); \
+      Serial.printf(format "\n", ##__VA_ARGS__);        \
+    }
+  #define LOGW(tag, format, ...)                        \
+    {                                                   \
+      Serial.printf("%6lu [%s] WARN: ", millis(), tag); \
+      Serial.printf(format "\n", ##__VA_ARGS__);        \
+    }
+  #define LOGE(tag, format, ...)                         \
+    {                                                    \
+      Serial.printf("%6lu [%s] ERROR: ", millis(), tag); \
+      Serial.printf(format "\n", ##__VA_ARGS__);         \
+    }
 #else
   #define LOGD(tag, format, ...) ESP_LOGD(tag, format, ##__VA_ARGS__)
   #define LOGI(tag, format, ...) ESP_LOGI(tag, format, ##__VA_ARGS__)


### PR DESCRIPTION
Changed the logic for logging so that it will be turned off fully when ESPCONNECT_DEBUG is not defined.
This will shave off ~2 kbytes in the final build and makes more features possible in SafeBoot.